### PR TITLE
fix for problems with dispatches using fx

### DIFF
--- a/examples/todomvc/project.clj
+++ b/examples/todomvc/project.clj
@@ -2,7 +2,7 @@
   :dependencies [[org.clojure/clojure        "1.9.0-alpha10"]
                  [org.clojure/clojurescript  "1.9.89"]
                  [reagent "0.6.0-rc"]
-                 [re-frame "0.9.0"]
+                 [re-frame "0.9.3"]
                  [binaryage/devtools "0.8.1"]
                  [day8.re-frame/test "0.1.3"]
                  [secretary "1.2.3"]]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.89"]
-                 [re-frame "0.8.0"]]
+                 [re-frame "0.9.3"]]
   :plugins [[lein-npm "0.6.2"]
             [lein-cljsbuild "1.1.3"]]
 

--- a/test/day8/re_frame/test_reframe/test_test.cljc
+++ b/test/day8/re_frame/test_reframe/test_test.cljc
@@ -144,9 +144,7 @@
       (rf/reg-event-fx :do-stuff
                        (fn [{:keys [db] :as cofx} event]
                          ;; Dispatch an event using cofx
-                         (rf/dispatch [:do-more-stuff])
-                         {}
-                         #_{:dispatch [:do-more-stuff]}))
+                         {:dispatch [:do-more-stuff]}))
       (rf/reg-event-db :do-more-stuff
                        (fn [db _] (assoc db :success true)))
 


### PR DESCRIPTION
Using re-frame.test/run-test-sync I’m getting ERROR You can't call dispatch-sync within an event handler. for handlers that return :dispatch fxs. Is there a workaround that doesn’t involve running async?

jfnt on clojurians slack

This will hopefully fix that problem