### PR TITLE
change *test-context* from dynvar to atom

### DIFF
--- a/src/day8/re_frame/test.cljc
+++ b/src/day8/re_frame/test.cljc
@@ -190,7 +190,7 @@
     (let [ok-pred   (as-callback-pred ok-ids)
           fail-pred (as-callback-pred failure-ids)
           cb-id     (gensym "wait-for-cb-fn")]
-      (rf/add-post-event-callback cb-id (fn [event _]
+      (rf/add-post-event-callback cb-id (#?(:cljs fn :clj bound-fn) [event _]
                                           ;; (taoensso.timbre/warn "post-event-callback: " event)
                                           (cond (and fail-pred
                                                      (not (test/is (not (fail-pred event))


### PR DESCRIPTION
because `*test-context*` was a dynvar it was causing problems with an async test with promise-based pre-conditions, meaning that `wait-for*` was being called from a random thread, and was unable to access the correct `*test-context*` value

this PR replaces the `*test-context*` dynvar of atoms with a `test-context*` atom of pure data